### PR TITLE
chore: update `.gitignore` and `dotenv` config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local env files 
+.env.local
+
 # Logs
 logs
 *.log

--- a/src/models/app.ts
+++ b/src/models/app.ts
@@ -1,7 +1,10 @@
 import { IConfig } from './config';
 import dotenv from 'dotenv';
+import fs from 'fs';
 
-dotenv.config({ path: '.env.local' || '.env' });
+const envPath = fs.existsSync('.env.local') ? '.env.local' : '.env';
+
+dotenv.config({ path: envPath });
 
 export const config: IConfig = {
   host: process.env.HOST || 'localhost',

--- a/src/models/app.ts
+++ b/src/models/app.ts
@@ -1,10 +1,8 @@
 import { IConfig } from './config';
 import dotenv from 'dotenv';
-import fs from 'fs';
 
-const envPath = fs.existsSync('.env.local') ? '.env.local' : '.env';
-
-dotenv.config({ path: envPath });
+dotenv.config();
+dotenv.config({ path: `.env.local`, override: true });
 
 export const config: IConfig = {
   host: process.env.HOST || 'localhost',

--- a/src/models/app.ts
+++ b/src/models/app.ts
@@ -1,7 +1,7 @@
 import { IConfig } from './config';
 import dotenv from 'dotenv';
 
-dotenv.config();
+dotenv.config({ path: '.env.local' || '.env' });
 
 export const config: IConfig = {
   host: process.env.HOST || 'localhost',


### PR DESCRIPTION
This PR aims to be able to create a local `.env` file that will be used in the `dotenv` configuration and will not be affected by `Git`