### PR TITLE
🚀 Release/v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.0.1](https://github.com/routelink/server/compare/v1.0.0...v1.0.1) (2024-05-30)
+
+
+### Features
+
+* edit transport ([#56](https://github.com/routelink/server/issues/56)) ([7205cc9](https://github.com/routelink/server/commit/7205cc97719b310e47974873aab6b186513f9794))
+* fill the table User via faker ([#55](https://github.com/routelink/server/issues/55)) ([0cc87a1](https://github.com/routelink/server/commit/0cc87a11986532b5707f3a0f7978f78497367ea7))
+* improve handler `api/analitycs/services/` ([#57](https://github.com/routelink/server/issues/57)) ([d8baa35](https://github.com/routelink/server/commit/d8baa3505cc38837b853add981dca8bb02f2d77e))
+
+
+### Bug Fixes
+
+* change endpoint to update transport ([f5c5cde](https://github.com/routelink/server/commit/f5c5cde4a7133bc735ed7a4f5969b787eb3b3688))
+* path of models ([1c6e157](https://github.com/routelink/server/commit/1c6e1579baa856a3b2a770aefd665db8210bfc9f))
+* row delete error ([#53](https://github.com/routelink/server/issues/53)) ([54e4253](https://github.com/routelink/server/commit/54e4253975bd0e873e3dfa0280dc1deba3953611))
+* row delete error ([#54](https://github.com/routelink/server/issues/54)) ([d3eab3c](https://github.com/routelink/server/commit/d3eab3c59e19f1e2ee87f0fc203c11995cd7749e))
+
 ## [1.0.0](https://github.com/routelink/server/compare/v0.0.1...v1.0.0) (2024-05-29)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@routelink/server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@routelink/server",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@routelink/server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "RouteLink server app",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
### [1.0.1](https://github.com/routelink/server/compare/v1.0.0...v1.0.1) (2024-05-30)

### Features

* edit transport ([#56](https://github.com/routelink/server/issues/56)) ([7205cc9](https://github.com/routelink/server/commit/7205cc97719b310e47974873aab6b186513f9794))
* fill the table User via faker ([#55](https://github.com/routelink/server/issues/55)) ([0cc87a1](https://github.com/routelink/server/commit/0cc87a11986532b5707f3a0f7978f78497367ea7))
* improve handler `api/analitycs/services/` ([#57](https://github.com/routelink/server/issues/57)) ([d8baa35](https://github.com/routelink/server/commit/d8baa3505cc38837b853add981dca8bb02f2d77e))

### Bug Fixes

* change endpoint to update transport ([f5c5cde](https://github.com/routelink/server/commit/f5c5cde4a7133bc735ed7a4f5969b787eb3b3688))
* path of models ([1c6e157](https://github.com/routelink/server/commit/1c6e1579baa856a3b2a770aefd665db8210bfc9f))
* row delete error ([#53](https://github.com/routelink/server/issues/53)) ([54e4253](https://github.com/routelink/server/commit/54e4253975bd0e873e3dfa0280dc1deba3953611))
* row delete error ([#54](https://github.com/routelink/server/issues/54)) ([d3eab3c](https://github.com/routelink/server/commit/d3eab3c59e19f1e2ee87f0fc203c11995cd7749e))

---

> **DO NOT SQUASH OR REBASE ME**

> if user merges this PR via rebasing or using squash, it will cause lost of the tag. It happens because tag is already
> attached to the initial release commit SHA. If we use rebase or squash, the commit sha changes and already created tag
> points to not-existing commit.